### PR TITLE
Add null checks in SdtTagName

### DIFF
--- a/sources/TemplateEngine.Docx/OpenXMLHelpers/XElementExtensions.cs
+++ b/sources/TemplateEngine.Docx/OpenXMLHelpers/XElementExtensions.cs
@@ -127,10 +127,10 @@ namespace TemplateEngine.Docx
 
 			try
 			{
-				return sdt
-					.Element(W.sdtPr)
-					.Element(W.tag)
-					.Attribute(W.val)
+				return sdt?
+					.Element(W.sdtPr)?
+					.Element(W.tag)?
+					.Attribute(W.val)?
 					.Value;
 			}
 			catch (Exception)


### PR DESCRIPTION
SdtTagName was throwing lots of exceptions, so I downloaded your code and took a look in debug mode.  The ".Element(W.tag)" part was null.  I added null checks (via the question marks), and it solved my problem and seems to run quite a bit faster.  I did not spend any time trying to understand your code, but if the try/catch is there just for handling nulls, maybe that is no longer needed.