### PR TITLE
Add number of hex digits to nsid format

### DIFF
--- a/sources/TemplateEngine.Docx/NumberingAccessor.cs
+++ b/sources/TemplateEngine.Docx/NumberingAccessor.cs
@@ -62,7 +62,7 @@ namespace TemplateEngine.Docx
 					var next = Random.Next(int.MaxValue);
 					var nsid = newAbstractNumElement.Element(W.nsid);
 					if (nsid != null)
-						nsid.Attribute(W.val).SetValue(next.ToString("X"));
+						nsid.Attribute(W.val).SetValue(next.ToString("X8"));
 
 					lastAbstractNumElement.AddAfterSelf(newAbstractNumElement);
 


### PR DESCRIPTION
Nsid is supposed to be a xs:hexBinary value. DotNets ToString function eats leading zeros by default so this value can end up as _ddddddd instead of 0ddddddd. While ms word doesnt seem to care, it shows up as a validation error in ms openxml productivity tools.