### PR TITLE
Create W.r inside W.p when writing value to empty content control

### DIFF
--- a/sources/TemplateEngine.Docx/OpenXMLHelpers/XElementExtensions.cs
+++ b/sources/TemplateEngine.Docx/OpenXMLHelpers/XElementExtensions.cs
@@ -57,13 +57,13 @@ namespace TemplateEngine.Docx
 					}
 					else
 					{
-						sdtContentElement.Add(new XElement(W.p), new XElement(W.r, new XElement(W.t, newValue)));
+						sdtContentElement.Add(new XElement(W.p, new XElement(W.r, new XElement(W.t, newValue))));
 					}
 				}
 			}
 			else
 			{
-				sdt.Add(new XElement(W.sdtContent, new XElement(W.p), new XElement(W.r, new XElement(W.t, newValue))));
+				sdt.Add(new XElement(W.sdtContent, new XElement(W.p, new XElement(W.r, new XElement(W.t, newValue)))));
 			}
 
 			ReplaceNewLinesWithBreaks(sdt);


### PR DESCRIPTION
Hi!
Ran into a situation where word document was corrupted after being processed with TemplateEngine.docx. The culprit was an empty W.p tag inside sdtContent, probably a typo.