### PR TITLE
fix \r\n

### DIFF
--- a/sources/TemplateEngine.Docx.Tests/Resources/DocumentWithSingleFieldFilledWithLinebreaks.xml
+++ b/sources/TemplateEngine.Docx.Tests/Resources/DocumentWithSingleFieldFilledWithLinebreaks.xml
@@ -1,2 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<w:document xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" mc:Ignorable="w14 wp14"><w:body><w:p w:rsidR="00EC1D4D" w:rsidRDefault="00ED7DA0" w:rsidP="00ED7DA0"><w:r w:rsidR="00EC1D4D"><w:t><w:t>09/06/2013</w:t><w:br /><w:t>Friday, 06 September 2013</w:t><w:br /><w:t>2013 September</w:t></w:t></w:r></w:p><w:sectPr w:rsidR="00EC1D4D" w:rsidSect="006E2549"><w:pgSz w:w="12240" w:h="15840" /><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0" /><w:cols w:space="720" /><w:docGrid w:linePitch="360" /></w:sectPr></w:body></w:document>
+<w:document xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" mc:Ignorable="w14 wp14">
+  <w:body>
+    <w:p w:rsidR="00EC1D4D" w:rsidRDefault="00ED7DA0" w:rsidP="00ED7DA0">
+      <w:r w:rsidR="00EC1D4D">
+        <w:t>09/06/2013</w:t>
+        <w:br />
+        <w:t>Friday, 06 September 2013</w:t>
+        <w:br />
+        <w:t>2013 September</w:t>
+      </w:r>
+    </w:p>
+    <w:sectPr w:rsidR="00EC1D4D" w:rsidSect="006E2549">
+      <w:pgSz w:w="12240" w:h="15840" />
+      <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0" />
+      <w:cols w:space="720" />
+      <w:docGrid w:linePitch="360" />
+    </w:sectPr>
+  </w:body>
+</w:document>

--- a/sources/TemplateEngine.Docx/OpenXMLHelpers/XElementExtensions.cs
+++ b/sources/TemplateEngine.Docx/OpenXMLHelpers/XElementExtensions.cs
@@ -143,18 +143,22 @@ namespace TemplateEngine.Docx
 		{
 			if (xElem == null) return;
 
-			var textWithBreaks = xElem.Descendants(W.t).Where(t => t.Value.Contains("\r\n"));
-			foreach (var textWithBreak in textWithBreaks)
-			{
+			var textWithBreaks = xElem.Descendants(W.t).Where(t => t.Value.Contains("\r\n")).ToList();
+            for (var i = textWithBreaks.Count - 1; i >= 0; i--)
+            {
+				var textWithBreak = textWithBreaks[i];
 				var text = textWithBreak.Value;
 				var split = text.Replace("\r\n", "\n").Split(new[] { "\n" }, StringSplitOptions.None);
-				textWithBreak.Value = string.Empty;
+
+				var parent = textWithBreak.Parent;
+				textWithBreak.Remove();
+
 				foreach (var s in split)
 				{
-					textWithBreak.Add(new XElement(W.t, s));
-					textWithBreak.Add(new XElement(W.br));
+					parent.Add(new XElement(W.t, s));
+					parent.Add(new XElement(W.br));
 				}
-				textWithBreak.Descendants(W.br).Last().Remove();
+				parent.Descendants(W.br).Last().Remove();
 			}
 		}
 	}

--- a/sources/TemplateEngine.Docx/OpenXMLHelpers/XElementExtensions.cs
+++ b/sources/TemplateEngine.Docx/OpenXMLHelpers/XElementExtensions.cs
@@ -143,7 +143,7 @@ namespace TemplateEngine.Docx
 		{
 			if (xElem == null) return;
 
-			var textWithBreaks = xElem.Descendants(W.t).Where(t => t.Value.Contains("\r\n")).ToList();
+			var textWithBreaks = xElem.Descendants(W.t).Where(t => t.Value.Contains("\n")).ToList();
             for (var i = textWithBreaks.Count - 1; i >= 0; i--)
             {
 				var textWithBreak = textWithBreaks[i];


### PR DESCRIPTION
Old:
 ```
<w:r>
    <w:t>
        <w:t>hello</w:t>
        <w:br />
        <w:t> word!</w:t>
    </w:t>
</w:r>
```
New:
```
<w:r>
    <w:t>hello</w:t>
    <w:br />
    <w:t> word!</w:t>
</w:r>
```

LibreOffice can't read this construction